### PR TITLE
Fix modtools to work with projects with vendor directory

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -147,7 +147,7 @@ func readDeps(updates bool) ([]Module, error) {
 	}
 	var args = []string{"list", "-m", "-json"}
 	if updates {
-		args = append(args, "-u")
+		args = append(args, "-u", "-mod=readonly")
 	}
 	set := make(map[string]struct{})
 	scanner := bufio.NewScanner(bytes.NewBuffer(out))


### PR DESCRIPTION
`go list -u` will fail if go version >=1.14 is used with a project that
has vendor directory, as it sets `-mod=vendor` but we can safely set it
to `-mod=readonly` so it can actually use the network to find out about
newer package versions.